### PR TITLE
fix presenceSub method

### DIFF
--- a/src/bot.js
+++ b/src/bot.js
@@ -391,7 +391,7 @@ class SlackBot extends Adapter {
    */
   presenceSub() {
     // Only subscribe to status changes from human users that are not deleted
-    const ids = this.robot.brain.data.users.filter(user => !user.is_bot && !user.deleted).map(user => user.id);
+    const ids = Object.entries(this.robot.brain.data.users).filter(([userId, user]) => !user.is_bot && !user.deleted).map(([userId, user]) => user.id);
     this.robot.logger.debug(`SlackBot#presenceSub() Subscribing to presence for ${ids.length} users`);
     return this.client.rtm.subscribePresence(ids);
   }


### PR DESCRIPTION
In the original coffeescript file it was
```coffeescript
  ids = for own id, user of @robot.brain.data.users when (not user.is_bot and not user.deleted)
      id
 ```
https://github.com/slackapi/hubot-slack/blob/b95707490356e2ce3ac7131796904d08b48201f6/src/bot.coffee#L183-L186

`users` is an object, so we can't just call `filter` on it