### PR TITLE
Remove unnecessary call to conversion info.

### DIFF
--- a/src/SlackAdapter.mjs
+++ b/src/SlackAdapter.mjs
@@ -211,9 +211,6 @@ class SlackAdapter extends Adapter {
         return text
     }
     async #onMessage(message) {
-        const channelResponse = await this.#webClient.conversations.info({
-            channel: message.event.channel
-        })
         const slackMessage = new SlackResponse(message)
         if(slackMessage.body.event.botId && slackMessage.body.event.user === this.robot.self.id) {
             this.robot.logger.info('Ignoring message from self')


### PR DESCRIPTION
###  Summary

The result of the channel info is not used. It gives a performance penalty, so I removed it.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/hubot-slack/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).