### PR TITLE
Improve error logging by adding the error to the log.

### DIFF
--- a/docs/_pages/basic_usage.md
+++ b/docs/_pages/basic_usage.md
@@ -267,7 +267,7 @@ module.exports = function(robot) {
     .then(function(api_response) {
       // List is searched for the channel with the right name, and the notification_room is updated
       const room = api_response.channels.find(channel => channel.name === default_channel_name);
-      if (room != null) { return notification_room = room.id; }}).catch(error => robot.logger.error(error.message));
+      if (room != null) { return notification_room = room.id; }}).catch(error => robot.logger.error(error, error.message));
 
   // Any message that says "send updates here" will change the notification room
   robot.hear(/send updates here/i, res => notification_room = res.message.rawMessage.channel.id);

--- a/src/bot.js
+++ b/src/bot.js
@@ -71,7 +71,7 @@ class SlackClient {
           );
         }
     }).catch(error => {
-        return this.robot.logger.error(`Error setting topic in conversation ${conversationId}: ${error.message}`);
+        return this.robot.logger.error(error, `Error setting topic in conversation ${conversationId}: ${error.message}`);
     });
   }
   send(envelope, message) {
@@ -84,11 +84,11 @@ class SlackClient {
     if (typeof message !== "string") {
       return this.web.chat.postMessage({ channel: room, text: message.text }).then(result => {
         this.robot.logger.debug(`Successfully sent message to ${room}`)
-      }).catch(e => this.robot.logger.error(`SlackClient#send(message) error: ${e.message}`))
+      }).catch(e => this.robot.logger.error(e, `SlackClient#send(message) error: ${e.message}`))
     } else {
       return this.web.chat.postMessage({ channel: room, text: message }).then(result => {
         this.robot.logger.debug(`Successfully sent message (string) to ${room}`)
-      }).catch(e => this.robot.logger.error(`SlackClient#send(string) error: ${e.message}`))
+      }).catch(e => this.robot.logger.error(e, `SlackClient#send(string) error: ${e.message}`))
     }
   }
   loadUsers(callback) {
@@ -165,7 +165,7 @@ class SlackClient {
     try {
       await this.eventHandler(event);
     } catch (error) {
-      this.robot.logger.error(`bot.js: eventWrapper: An error occurred while processing an event from SlackBot's SlackClient: ${error.message}.`);
+      this.robot.logger.error(error, `bot.js: eventWrapper: An error occurred while processing an event from SlackBot's SlackClient: ${error.message}.`);
     }
   }
 }
@@ -365,7 +365,7 @@ class SlackBot extends Adapter {
    * @param error - An error emitted
    */
   error(error) {
-    this.robot.logger.error(`SlackBot error: ${JSON.stringify(error)}`);
+    this.robot.logger.error(error, `SlackBot error`);
     // Assume that scripts can handle slowing themselves down, all other errors are bubbled up through Hubot
     // NOTE: should rate limit errors also bubble up?
     if (error.code !== -1) {
@@ -494,7 +494,7 @@ class SlackBot extends Adapter {
         default:
           this.robot.logger.debug(`Received generic message: ${message.event.type}`);
           SlackTextMessage.makeSlackTextMessage(from, null, message?.body?.event.text, message?.body?.event, channel, this.robot.name, this.robot.alias, this.client, (error, message) => {
-            if (error) { return this.robot.logger.error(`Dropping message due to error ${error.message}`); }
+            if (error) { return this.robot.logger.error(error, `Dropping message due to error ${error.message}`); }
             return this.receive(message);
           });
           break;

--- a/src/client.js
+++ b/src/client.js
@@ -87,7 +87,7 @@ class SlackClient extends EventEmitter {
       this.robot.logger.info('Connected to Slack after starting socket client.');
       // this.emit('connected');
     } catch (e) {
-      this.robot.logger.error(`Error connecting to Slack: ${e.message}`);
+      this.robot.logger.error(e, `Error connecting to Slack: ${e.message}`);
       this.emit('error', e);
     }
     return startResponse;
@@ -139,7 +139,7 @@ class SlackClient extends EventEmitter {
         return this.robot.logger.debug(`Conversation ${conversationId} is a DM or MPDM. These conversation types do not have topics.`);
       }
     } catch (e) {
-      this.robot.logger.error(`Error setting topic in conversation ${conversationId}: ${e.message}`);
+      this.robot.logger.error(e, `Error setting topic in conversation ${conversationId}: ${e.message}`);
     }
   }
 
@@ -202,12 +202,12 @@ class SlackClient extends EventEmitter {
     if (typeof message !== "string") {
       return this.web.chat.postMessage({channel: room, text: message.text}, Object.assign(message, options))
         .catch(error => {
-          return this.robot.logger.error(`SlackClient#send() error: ${error.message}`);
+          return this.robot.logger.error(error, `SlackClient#send() error: ${error.message}`);
       });
     } else {
       return this.web.chat.postMessage({channel: room, text: message.text}, options)
         .catch(error => {
-          return this.robot.logger.error(`SlackClient#send() error: ${error.message}`);
+          return this.robot.logger.error(error, `SlackClient#send() error: ${error.message}`);
       });
     }
   }
@@ -411,10 +411,10 @@ class SlackClient extends EventEmitter {
             this.eventHandler(fetchedEvent);
           }
           catch (error) {
-            this.robot.logger.error(`An error occurred while processing an event: from Slack Client ${error.message}.`);
+            this.robot.logger.error(error, `An error occurred while processing an event: from Slack Client ${error.message}.`);
           }
         }).catch(error => {
-          return this.robot.logger.error(`Incoming message dropped due to error fetching info for a property: ${error.message}.`);
+          return this.robot.logger.error(error, `Incoming message dropped due to error fetching info for a property: ${error.message}.`);
       });
     }
   }

--- a/src/message.js
+++ b/src/message.js
@@ -138,7 +138,7 @@ class SlackTextMessage extends TextMessage {
         this.text = text;
         return cb();
     }).catch(error => {
-        client.robot.logger.error(`An error occurred while building text: ${error.message}`);
+        client.robot.logger.error(error, `An error occurred while building text: ${error.message}`);
         return cb(error);
     });
   }
@@ -225,7 +225,7 @@ class SlackTextMessage extends TextMessage {
         mentions.push(new SlackMention(res.id, "user", res));
         return `@${res.name}`;
     }).catch(error => {
-        client.robot.logger.error(`Error getting user info ${id}: ${error.message}`);
+        client.robot.logger.error(error, `Error getting user info ${id}: ${error.message}`);
         return `<@${id}>`;
     });
   }
@@ -247,7 +247,7 @@ class SlackTextMessage extends TextMessage {
           return `\#${conversation.name}`;
         } else { return `<\#${id}>`; }
     }).catch(error => {
-        client.robot.logger.error(`Error getting conversation info ${id}: ${error.message}`);
+        client.robot.logger.error(error, `Error getting conversation info ${id}: ${error.message}`);
         return `<\#${id}>`;
     });
   }


### PR DESCRIPTION
###  Summary

Hubot uses the pino logger. Errors can be logged directly to the logger by `robot.logger.error(err, msg)`. More info here: https://betterstack.com/community/guides/logging/how-to-install-setup-and-use-pino-to-log-node-js-applications/#logging-errors-with-pino

I've added the error objects to the logger so we can view the error details. This will fix #20 .

I've ran the tests and they succeed:

![image](https://github.com/hubot-friends/hubot-slack/assets/583193/635cb2b9-6e3c-40e1-bbc0-5a0d7f789514)


### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/hubot-slack/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).