### PR TITLE
Keep message properties like `mrkdwn` and `attachments`

### DIFF
--- a/src/bot.js
+++ b/src/bot.js
@@ -82,7 +82,8 @@ class SlackClient {
     }
     this.robot.logger.debug(`SlackClient#send() room: ${room}, message: ${message}`);
     if (typeof message !== "string") {
-      return this.web.chat.postMessage({ channel: room, text: message.text }).then(result => {
+      message.channel = room
+      return this.web.chat.postMessage(message).then(result => {
         this.robot.logger.debug(`Successfully sent message to ${room}`)
       }).catch(e => this.robot.logger.error(`SlackClient#send(message) error: ${e.message}`))
     } else {


### PR DESCRIPTION
###  Summary

The https://api.slack.com/methods/chat.postMessage endpoint supports many properties. The old slack adapter passed them through, but the new one doesn't, which will cause upgrades to fail. To remedy this, I keep the message as is, but just add a `.channel` property to it.

This means that code like this will start to work again: 

```js
var answer = {
    text: `:pulse: Puma system status `,
    mrkdwn: true,
    attachments: [
      {
        color: "#dddddd",
        fields: [
          {
            title: ":rocket: Puma lag status",
            value: lagPumaMessage,
            short: true,
          },
          {
            title: ":elastic: Elastic lag status",
            value: elasticMessage,
            short: true,
          },
        ],
      },
    ],
  }
  res.emote(answer)
```

Tests are succeeding:

![image](https://github.com/hubot-friends/hubot-slack/assets/583193/3bcc2f8d-aff0-434e-ac34-80eec92a21d7)


### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/hubot-slack/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).