### PR TITLE
fix: Responding to messages when started with alias (--alias)

### DIFF
--- a/src/bot.js
+++ b/src/bot.js
@@ -379,7 +379,11 @@ class SlackBot extends Adapter {
       const botName = this.self.user;
       const text = event.text ?? event.message?.text ?? '';
       if(text.includes(`<@${botId}>`)) {
+        if(this.robot.alias) {
+          return text.replace(`<@${botId}>`, `${this.robot.alias}`);
+        } else {
           return text.replace(`<@${botId}>`, `@${botName}`);
+        }
       }
       return text;
   }

--- a/test/bot.js
+++ b/test/bot.js
@@ -1,6 +1,7 @@
 const {describe, it, beforeEach, before, after} = require('node:test');
 const assert = require('node:assert/strict');
 const Module = require('module');
+const SlackBot = require('../src/bot.js');
 
 const hookModuleToReturnMockFromRequire = (module, mock) => {
   const originalRequire = Module.prototype.require;
@@ -347,6 +348,18 @@ describe('Handling incoming messages', function() {
       done();
     };
     slackbot.eventHandler({body: { event: { text: 'foo', type: 'message', user: stubs.user.id, channel_type: 'im' }}, event: { text: 'foo', type: 'message', user: stubs.user.id, channel_type: 'im', channel:stubs.DM.id }});
+  });
+
+  it('Should preprend our alias to a name-lacking message addressed to us in a DM', function(t, done) {
+   const bot = new SlackBot({alias: '!', logger: {info(){}, debug(){}}}, {appToken: ''});
+   bot.self = {
+    user_id: '1234'
+   }
+   const text = bot.replaceBotIdWithName({
+      text: '<@1234> foo',
+   })
+    assert.deepEqual(text, '! foo');
+    done()
   });
 
   it('Should NOT prepend our name to a name-containing message addressed to us in a DM', function(t, done) {


### PR DESCRIPTION
###  Summary

fixes #25 . Code was not taking into account a Hubot instance started with an alias (--alias). Modified the code to use alias if it's set on the robot instance.

### Requirements (place an `x` in each `[ ]`)

* [ x ] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/hubot-slack/blob/master/.github/contributing.md) and have done my best effort to follow them.
* [ x ] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).