### PR TITLE
fix: update peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "node": ">= 18"
   },
   "peerDependencies": {
-    "hubot": "^12.0.0"
+    "hubot": "^13.0.0"
   },
   "devDependencies": {
     "pino-pretty": "^10.0.1"


### PR DESCRIPTION
Fixes issue #53.

###  Summary

Hubot was upgraded. In order for me to upgrade we need to fix the peer dependency which only allows for 12.

### Requirements (place an `x` in each `[ ]`)

* [ ] I've read and understood the [Contributing Guidelines](./contributing.md) and have done my best effort to follow them.
^--- looks that this file is missing