### PR TITLE
Add Hubot 14 compatibility in peer dependency range

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "node": ">= 18"
       },
       "peerDependencies": {
-        "hubot": "^13.0.0"
+        "hubot": "^13.0.0 || ^14.0.0"
       }
     },
     "node_modules/@slack/logger": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "node": ">= 18"
   },
   "peerDependencies": {
-    "hubot": "^13.0.0"
+    "hubot": "^13.0.0 || ^14.0.0"
   },
   "devDependencies": {
     "pino-pretty": "^10.0.1"


### PR DESCRIPTION
Fixes https://github.com/hubot-friends/hubot-slack/issues/58

###  Summary

- Resolves issue #58 by declaring compatibility with the latest Hubot release (14.1.0).
- Expands adapter peer dependency from ^13.0.0 to ^13.0.0 || ^14.0.0.
- Updates lockfile metadata to keep package definitions consistent.

### Requirements (place an `x` in each `[ ]`)

* [x] I've read and understood the [Contributing Guidelines](./.github/contributing.md) and have done my best effort to follow them.
