### PR TITLE
fix: handle reaction item_user as string

### DIFF
--- a/src/Bot.mjs
+++ b/src/Bot.mjs
@@ -517,9 +517,8 @@ class SlackBot extends Adapter {
           // conversation. In that situation we fallback to an empty string.
           from.room = message.body.event.item.type === "message" ? message.body.event.item.channel : "";
   
-          // Reaction messages may contain an `event.item_user` property containing a fetched SlackUserInfo object. Before
-          // the message is received by Hubot, turn that data into a Hubot User object.
-          const item_user = (message.body.event.item_user != null) ? this.robot.brain.userForId(message.body.event.item_user.id, message.body.event.item_user) : {};
+          // The Slack API sends event.item_user as a plain user ID string, not a user object.
+          const item_user = (message.body.event.item_user != null) ? this.robot.brain.userForId(message.body.event.item_user) : {};
   
           this.robot.logger.debug(`Received reaction message from: ${from.id}, reaction: ${message.body.event.reaction}, item type: ${message.body.event.item.type}`);
           await this.receive(new ReactionMessage(message.body.event.type, from, message.body.event.reaction, item_user, message.body.event.item, message.body.event.event_ts));

--- a/test/Bot.mjs
+++ b/test/Bot.mjs
@@ -580,7 +580,7 @@ describe('Handling incoming messages', () => {
         event: {
           type: 'reaction_added',
           user: stubs.user.id,
-          item_user: stubs.self,
+          item_user: stubs.user.id,
           channel: stubs.channel.id,
           ts: stubs.event_timestamp,
           item: {
@@ -596,7 +596,7 @@ describe('Handling incoming messages', () => {
       event: {
         type: 'reaction_added',
         user: stubs.user.id,
-        item_user: stubs.self,
+        item_user: stubs.user.id,
         channel: stubs.channel.id,
         ts: stubs.event_timestamp,
         item: {
@@ -613,7 +613,7 @@ describe('Handling incoming messages', () => {
       assert.deepEqual((msg instanceof ReactionMessage), true)
       assert.deepEqual(msg.user.id, stubs.user.id)
       assert.deepEqual(msg.user.room, stubs.channel.id)
-      assert.deepEqual(msg.item_user.id, stubs.self.id)
+      assert.deepEqual(msg.item_user.id, stubs.user.id)
       assert.deepEqual(msg.type, 'added')
       assert.deepEqual(msg.reaction, 'thumbsup')
       done()
@@ -627,7 +627,7 @@ describe('Handling incoming messages', () => {
         event: {
           type: 'reaction_removed',
           user: stubs.user.id,
-          item_user: stubs.self,
+          item_user: stubs.user.id,
           channel: stubs.channel.id,
           ts: stubs.event_timestamp,
           item: {
@@ -643,7 +643,7 @@ describe('Handling incoming messages', () => {
       event: {
         type: 'reaction_removed',
         user: stubs.user.id,
-        item_user: stubs.self,
+        item_user: stubs.user.id,
         channel: stubs.channel.id,
         ts: stubs.event_timestamp,
         item: {
@@ -659,7 +659,7 @@ describe('Handling incoming messages', () => {
       assert.deepEqual((msg instanceof ReactionMessage), true)
       assert.deepEqual(msg.user.id, stubs.user.id)
       assert.deepEqual(msg.user.room, stubs.channel.id)
-      assert.deepEqual(msg.item_user.id, stubs.self.id)
+      assert.deepEqual(msg.item_user.id, stubs.user.id)
       assert.deepEqual(msg.type, 'removed')
       assert.deepEqual(msg.reaction, 'thumbsup')
       done()


### PR DESCRIPTION
## Summary
- handle Slack reaction event `item_user` as the string user ID Slack sends
- avoid calling `userForId(item_user.id, item_user)` with an invalid shape
- update reaction tests to use realistic `item_user` payload values and assertions

## Problem
Slack sends `event.item_user` as a string user ID in `reaction_added`/`reaction_removed` payloads. The old code treated it as an object and dereferenced `.id`, which could throw and drop reaction events.

## Testing
- updated existing reaction tests in `test/Bot.mjs`

Closes #61